### PR TITLE
Update DragDropView.java

### DIFF
--- a/DragDrop/src/niko/dragdrop/view/DragDropView.java
+++ b/DragDrop/src/niko/dragdrop/view/DragDropView.java
@@ -95,8 +95,10 @@ public class DragDropView extends FrameLayout {
 				}
 				case MotionEvent.ACTION_UP:
 				{
-					dragParam.height = 150;
-					dragParam.width = 150;
+				//	dragParam.height = 150;
+				//	dragParam.width = 150;
+					dragParam.height = v.getHeight();
+                		        dragParam.width = v.getWidth();
 					dragParam.topMargin = (int)event.getRawY() - (v.getHeight());
 					dragParam.leftMargin = (int)event.getRawX() - (v.getWidth()/2);
 					v.setLayoutParams(dragParam);
@@ -104,8 +106,10 @@ public class DragDropView extends FrameLayout {
 				}
 				case MotionEvent.ACTION_DOWN:
 				{
-					dragParam.height = 100;
-					dragParam.width = 100;
+				//	dragParam.height = 100;
+				//	dragParam.width = 100;
+				        dragParam.height = v.getHeight();
+                		        dragParam.width = v.getWidth();
 					v.setLayoutParams(dragParam);
 					break;
 				}


### PR DESCRIPTION
Instead of setting hardcoded FrameLayout.LayoutParams height and width which gave wrong drop points and ended put displaying a quarter of the image if it was too big, I recommend getting the imageview height and width then setting it to the layout, this worked perfectly in my code, and thanks to Niko it would not have been possible if he had not made this file in the first place
